### PR TITLE
Added support for root to be a zip file.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,5 +48,5 @@ pluginBundle {
 }
 
 task wrapper(type: Wrapper) {
-    gradleVersion = '2.14.1'
+    gradleVersion = '4.8.1'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8.1-bin.zip

--- a/src/main/groovy/uk/jamierocks/propatcher/ProPatcherPlugin.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/ProPatcherPlugin.groovy
@@ -32,10 +32,6 @@ import uk.jamierocks.propatcher.task.MakePatchesTask
 import uk.jamierocks.propatcher.task.ResetSourcesTask
 
 class ProPatcherPlugin implements Plugin<Project> {
-
-    static final File DEV_NULL = new File('/dev/null')
-    static final File WINDOWS_NUL = new File('nul')
-
     @Override
     void apply(Project project) {
         project.with {

--- a/src/main/groovy/uk/jamierocks/propatcher/task/ApplyPatchesTask.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/task/ApplyPatchesTask.groovy
@@ -50,8 +50,6 @@ class ApplyPatchesTask extends DefaultTask {
                 patch.patch(false).each { report ->
                     if (report.status == PatchStatus.Patched) {
                         report.originalBackupFile.delete() //lets delete the backup because spam
-                        if (report.file.text == '') //Empty result == patch deleted file, so lets delete!
-                            report.file.delete()
                     } else {
                         failed = true
                         println 'Failed to apply: ' + file
@@ -60,6 +58,10 @@ class ApplyPatchesTask extends DefaultTask {
                 }
             }
         }
+        def NUL = new File('/dev/null')
+        if (System.getProperty('os.name').toLowerCase().contains('win') && NUL.exists()) //patcher is standerdized to create /dev/null targets even on windows, so delete this to clean that up
+            NUL.delete()
+            
         if (failed)
             throw new RuntimeException('One or more patches failed to apply, see log for details')
     }

--- a/src/main/groovy/uk/jamierocks/propatcher/task/MakePatchesTask.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/task/MakePatchesTask.groovy
@@ -49,7 +49,7 @@ class MakePatchesTask extends DefaultTask {
     @Input @Optional String modifiedPrefix = 'b/'
 
     def relative(base, file) {
-        return file.path.substring(target.path.length() + 1).replaceAll(Matcher.quoteReplacement(File.separator), '/') //Replace is to normalize windows to linux/zip format
+        return file.path.substring(base.path.length() + 1).replaceAll(Matcher.quoteReplacement(File.separator), '/') //Replace is to normalize windows to linux/zip format
     }
     def deleteEmpty(base) {
         def dirs = []

--- a/src/main/groovy/uk/jamierocks/propatcher/task/MakePatchesTask.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/task/MakePatchesTask.groovy
@@ -67,7 +67,7 @@ class MakePatchesTask extends DefaultTask {
 
     void process(File root, File target) {
         def paths = []
-        target.eachFileRecurse(FileType.FILES){ file -> if (!file.endsWith('~')) paths.add relative(target, file) }
+        target.eachFileRecurse(FileType.FILES){ file -> if (!file.path.endsWith('~')) paths.add relative(target, file) }
         if (root.isDirectory()) {
             root.eachFileRecurse(FileType.FILES) { file ->
                 def relative = relative(root, file)
@@ -87,8 +87,8 @@ class MakePatchesTask extends DefaultTask {
     }
     
     def makePatch(relative, original, modified) {
-        String originalRelative = originalPrefix + relative
-        String modifiedRelative = modifiedPrefix + relative
+        String originalRelative = original == null ? '/dev/null' : originalPrefix + relative
+        String modifiedRelative = !modified.exists() ? '/dev/null' : modifiedPrefix + relative
         
         def originalData = original == null ? "" : original.getText("UTF-8")
         def modifiedData = !modified.exists() ? "" : modified.getText("UTF-8")

--- a/src/main/groovy/uk/jamierocks/propatcher/task/ResetSourcesTask.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/task/ResetSourcesTask.groovy
@@ -37,7 +37,7 @@ class ResetSourcesTask extends DefaultTask {
     File target
 
     def relative(base, file) {
-        return file.path.substring(target.path.length() + 1).replaceAll(Matcher.quoteReplacement(File.separator), '/') //Replace is to normalize windows to linux/zip format
+        return file.path.substring(base.path.length() + 1).replaceAll(Matcher.quoteReplacement(File.separator), '/') //Replace is to normalize windows to linux/zip format
     }
     def deleteEmpty(base) {
         def dirs = []


### PR DESCRIPTION
Added support for root to be a zip file.
This prevents the need to have the 'clean' source fully extracted to disc.

Rewrote the ResetSource task to not do bulk delete/remake.
This saves massive wear and tear on harddrives.

Standardized makePatches to use /dev/null as the null file identifier, and use / as the folder separator. Stabelizes the patches generated between linux and windows.

Changed the Apply task to print out failures, cleanup the backup file on successful patches, made it delete /dev/null on windows as the patcher will create it.

Also added a way to configure the path files prefixes, as it's nice to diff against patches made with different tools.

Also bumped gradlewrapper to make it work on JDK9. 