### PR TITLE
Fix annotations

### DIFF
--- a/src/main/groovy/uk/jamierocks/propatcher/ProPatcherExtension.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/ProPatcherExtension.groovy
@@ -26,17 +26,19 @@
 package uk.jamierocks.propatcher
 
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
 
 class ProPatcherExtension {
 
-    @InputFile
-    File root
+    @InputFile @Optional File rootZip = null
+    @InputDirectory @Optional File rootDir = null
 
-    @InputFile
+    @InputDirectory
     File target
 
-    @InputFile
+    @InputDirectory
     File patches
 
     @Input

--- a/src/main/groovy/uk/jamierocks/propatcher/ProPatcherPlugin.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/ProPatcherPlugin.groovy
@@ -45,7 +45,8 @@ class ProPatcherPlugin implements Plugin<Project> {
 
             afterEvaluate {
                 tasks.makePatches.with {
-                    root = extension.root
+                    rootZip = extension.rootZip
+                    rootDir = extension.rootDir
                     target = extension.target
                     patches = extension.patches
                     originalPrefix = extension.originalPrefix
@@ -56,7 +57,8 @@ class ProPatcherPlugin implements Plugin<Project> {
                     patches = extension.patches
                 }
                 tasks.resetSources.with {
-                    root = extension.root
+                    rootZip = extension.rootZip
+                    rootDir = extension.rootDir
                     target = extension.target
                 }
             }

--- a/src/main/groovy/uk/jamierocks/propatcher/task/ApplyPatchesTask.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/task/ApplyPatchesTask.groovy
@@ -31,13 +31,13 @@ import com.cloudbees.diff.ContextualPatch
 import com.cloudbees.diff.ContextualPatch.PatchStatus
 import com.cloudbees.diff.PatchException
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.TaskAction
 
 class ApplyPatchesTask extends DefaultTask {
 
-    @InputFile File target
-    @InputFile File patches
+    @InputDirectory File target
+    @InputDirectory File patches
 
     @TaskAction
     void doTask() {

--- a/src/main/groovy/uk/jamierocks/propatcher/task/MakePatchesTask.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/task/MakePatchesTask.groovy
@@ -29,6 +29,7 @@ import com.cloudbees.diff.Diff
 import groovy.io.FileType
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
@@ -39,9 +40,10 @@ import java.util.zip.ZipFile
 
 class MakePatchesTask extends DefaultTask {
 
-    @InputFile File root
-    @InputFile File target
-    @InputFile File patches
+    @InputFile @Optional File rootZip = null
+    @InputDirectory @Optional File rootDir = null
+    @InputDirectory File target
+    @InputDirectory File patches
     @Input @Optional String originalPrefix = 'a/'
     @Input @Optional String modifiedPrefix = 'b/'
     @Input boolean ignoreWhitespace = true
@@ -61,6 +63,9 @@ class MakePatchesTask extends DefaultTask {
         if (!patches.exists())
             patches.mkdirs()
 
+        def root = rootZip == null ? rootDir : rootZip
+        if (root == null)
+            throw new RuntimeException("At least one of rootZip and rootDir has to be specified!")
         process(root, target) // Make the patches
     }
 

--- a/src/main/groovy/uk/jamierocks/propatcher/task/MakePatchesTask.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/task/MakePatchesTask.groovy
@@ -28,6 +28,7 @@ package uk.jamierocks.propatcher.task
 import com.cloudbees.diff.Diff
 import groovy.io.FileType
 import org.gradle.api.DefaultTask
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
@@ -65,7 +66,7 @@ class MakePatchesTask extends DefaultTask {
 
         def root = rootZip == null ? rootDir : rootZip
         if (root == null)
-            throw new RuntimeException("At least one of rootZip and rootDir has to be specified!")
+            throw new InvalidUserDataException("At least one of rootZip and rootDir has to be specified!")
         process(root, target) // Make the patches
     }
 

--- a/src/main/groovy/uk/jamierocks/propatcher/task/ResetSourcesTask.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/task/ResetSourcesTask.groovy
@@ -27,6 +27,7 @@ package uk.jamierocks.propatcher.task
 
 import groovy.io.FileType
 import org.gradle.api.DefaultTask
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
@@ -58,7 +59,7 @@ class ResetSourcesTask extends DefaultTask {
         target.eachFileRecurse(FileType.FILES){ file -> existing.add relative(target, file) }
         def root = rootZip == null ? rootDir : rootZip
         if (root == null)
-            throw new RuntimeException("At least one of rootZip and rootDir has to be specified!")
+            throw new InvalidUserDataException("At least one of rootZip and rootDir has to be specified!")
         if (root.isDirectory()) {
             root.eachFileRecurse { file ->
                 def relative = relative(root, file)

--- a/src/main/groovy/uk/jamierocks/propatcher/task/ResetSourcesTask.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/task/ResetSourcesTask.groovy
@@ -27,15 +27,18 @@ package uk.jamierocks.propatcher.task
 
 import groovy.io.FileType
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import java.util.regex.Matcher
 import java.util.zip.ZipFile
 
 class ResetSourcesTask extends DefaultTask {
 
-    @InputFile File root
-    @InputFile File target
+    @InputFile @Optional File rootZip = null
+    @InputDirectory @Optional File rootDir = null
+    @InputDirectory File target
 
     static def relative(base, file) {
         return file.path.substring(base.path.length() + 1).replaceAll(Matcher.quoteReplacement(File.separator), '/') //Replace is to normalize windows to linux/zip format
@@ -53,6 +56,9 @@ class ResetSourcesTask extends DefaultTask {
         if (!target.exists())
             target.mkdirs()
         target.eachFileRecurse(FileType.FILES){ file -> existing.add relative(target, file) }
+        def root = rootZip == null ? rootDir : rootZip
+        if (root == null)
+            throw new RuntimeException("At least one of rootZip and rootDir has to be specified!")
         if (root.isDirectory()) {
             root.eachFileRecurse { file ->
                 def relative = relative(root, file)


### PR DESCRIPTION
Gradle distinguishes between a File and a Directory for the input annotations. Had to work around the inputs that could be both zips or dirs by having them be distinct optional inputs and throwing if both aren't specified.