### PR TITLE
Fix `ignoreWhitespace` incompatibility with Gradle 7

### DIFF
--- a/src/main/groovy/uk/jamierocks/propatcher/task/MakePatchesTask.groovy
+++ b/src/main/groovy/uk/jamierocks/propatcher/task/MakePatchesTask.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
@@ -47,7 +48,7 @@ class MakePatchesTask extends DefaultTask {
     @InputDirectory File patches
     @Input @Optional String originalPrefix = 'a/'
     @Input @Optional String modifiedPrefix = 'b/'
-    @Input boolean ignoreWhitespace = true
+    private boolean ignoreWhitespace = true
 
     static def relative(base, file) {
         return file.path.substring(base.path.length() + 1).replaceAll(Matcher.quoteReplacement(File.separator), '/') //Replace is to normalize windows to linux/zip format
@@ -115,4 +116,13 @@ class MakePatchesTask extends DefaultTask {
         }
     }
 
+    @Input
+    boolean isIgnoreWhitespace() {
+        return ignoreWhitespace
+    }
+
+    @Internal
+    boolean getIgnoreWhitespace() {
+        return ignoreWhitespace
+    }
 }


### PR DESCRIPTION
For `MakePatchesTask.ignoreWhitespace`, Groovy automatically generates both `isIgnoreWhitspace()` and `getIgnoreWhitespace()` for boolean properties. This has issues with Gradle 7.2/6.9.1, resulting in the following error:
```java
  - Type 'uk.jamierocks.propatcher.task.MakePatchesTask' property 'ignoreWhitespace' has redundant getters: 'getIgnoreWhitespace()' and 'isIgnoreWhitespace()'.
```
This has been fixed in this PR by keeping both getters, but marking one as `@Input` and one as `@Internal` to preserve compatibility.